### PR TITLE
restores the original name of gem

### DIFF
--- a/mini_record.gemspec
+++ b/mini_record.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 require "mini_record/version"
 
 Gem::Specification.new do |s|
-  s.name        = "mini_record-cj"
+  s.name        = "mini_record"
   s.version     = MiniRecord::VERSION
   s.authors     = ["Davide D'Agostino"]
   s.email       = ["d.dagostino@lipsiasoft.com"]


### PR DESCRIPTION
#### why?

We should preserve the original name of gem unless we are planning to release custom version to a gems server. Due to right now We are going to host this fork and We are not planning to publish our custom gem I'm restoring the original name. Also if We renamed the gem we should be consistent and renamed the folders and files name.