### PR TITLE
bumps acdcorp version to 0.3.8

### DIFF
--- a/lib/mini_record/version.rb
+++ b/lib/mini_record/version.rb
@@ -1,3 +1,3 @@
 module MiniRecord
-  VERSION = "0.3.7"
+  VERSION = "0.3.8"
 end


### PR DESCRIPTION
#### what?

This is a new acdcorp version and might be different from original repository version. This will sit in a new stable branch `0-3-8-acdcorp-stable` and new tag `v0.3.8`.