### PR TITLE
updates activerecord version to 4.2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ use [fork-stable](https://github.com/acdcorp/mini_record/tree/fork-stable) or
 
 Please use this branch [0.3-acdcorp-stable](https://github.com/acdcorp/mini_record/tree/0.3-acdcorp-stable)
 
+### ActiveRecord 4.2.11 and Ruby >= 2.5.5 and 2.6.6
+
+Please use version 0.3.11
+
 ## Author
 
 DAddYE, you can follow me on twitter [@daddye](http://twitter.com/daddye) or take a look at my site [daddye.it](http://www.daddye.it)

--- a/mini_record.gemspec
+++ b/mini_record.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
-  s.add_runtime_dependency "activerecord", '~> 4.2'
+  s.add_runtime_dependency "activerecord", '~> 4.2.11'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest'


### PR DESCRIPTION
#### Summary

This requires activerecord 4.2.11 to support newest and latest 4 version within conjoin, cuba and subro apps